### PR TITLE
docs: add copilot-instructions and improve README

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,54 @@
+# Copilot Instructions for `goark/gocli`
+
+## Project purpose
+
+`gocli` is a collection of small, focused packages for building command-line tools in Go.
+Each sub-package addresses one concern: I/O handling, exit codes, signal handling, file globbing, and XDG directories.
+
+## Design principles
+
+- Keep each sub-package small and focused on a single responsibility.
+- Prefer explicit, simple APIs over feature-rich abstractions.
+- Preserve backward compatibility when possible; avoid breaking public symbols.
+- Use functional options (`OptFunc`) where configuration is needed.
+
+## Coding style
+
+- Write idiomatic Go. Keep implementation straightforward.
+- Always add a space after `//` in comments: `// Foo`, not `//Foo`.
+- Add a blank line before `Deprecated:` in doc comments.
+- Avoid unnecessary external dependencies.
+- Keep comments concise and in English.
+
+## Error handling
+
+- Return errors explicitly; do not panic in library code.
+- Keep error sentinel behavior compatible with `errors.Is`.
+
+## Testing and validation
+
+- Add or update tests for behavior changes.
+- Run local validation with:
+
+```text
+task test
+```
+
+- `task test` runs: `go mod verify`, `go test -shuffle on ./...`, and golangci-lint.
+
+## Release process
+
+- Create release tags from `master`.
+- Use semantic versioning tags in `vMAJOR.MINOR.PATCH` format.
+- Ensure the local repository is clean and synced before tagging.
+
+Release steps:
+
+1. Ensure `master` is up to date.
+2. Create annotated tag:
+   - `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
+3. Push tag:
+   - `git push origin vX.Y.Z`
+4. Create GitHub release with auto-generated notes:
+   - `gh release create vX.Y.Z --generate-notes`
+5. Verify the release on GitHub.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,35 @@
 [![lint status](https://github.com/goark/gocli/workflows/lint/badge.svg)](https://github.com/goark/gocli/actions)
 [![GitHub license](https://img.shields.io/badge/license-CC0-blue.svg)](https://raw.githubusercontent.com/goark/gocli/master/LICENSE)
 [![GitHub release](https://img.shields.io/github/release/goark/gocli.svg)](https://github.com/goark/gocli/releases/latest)
+[![Go Reference](https://pkg.go.dev/badge/github.com/goark/gocli.svg)](https://pkg.go.dev/github.com/goark/gocli)
 
-This package is required Go 1.16 or later.
+This package requires Go 1.20 or later.
 
-**Migrated repository to [github.com/goark/gocli][gocli]**
+## Design goals
+
+`gocli` provides a small collection of focused sub-packages for building command-line tools in Go.
+Each package addresses a single concern:
+
+- `exitcode` — OS exit code constants and helpers
+- `rwi` — Reader/Writer interface wrapping stdin/stdout/stderr
+- `signal` — Signal handling via `context.Context`
+- `file` — File/directory globbing with wildcard support
+- `config` — XDG-aware configuration file path helpers
+- `cache` — XDG-aware cache file path helpers
+
+## Development
+
+Requires [Task] for local validation.
+
+```text
+task test
+```
+
+This runs `go mod verify`, `go test -shuffle on ./...`, and golangci-lint.
 
 ## Declare [gocli] module
 
-See [go.mod](https://github.com/goark/gocli/blob/master/go.mod) file. 
+See [go.mod](https://github.com/goark/gocli/blob/master/go.mod) file.
 
 ## Usage of [gocli] package
 
@@ -143,6 +164,6 @@ fmt.Println(path)
 // /home/username/.cache/app/access.log
 ```
 
-[gocli]: https://github.com/goark/gocli "goark/gocli: Make Link with Markdown Format"
-[dep]: https://github.com/golang/dep "golang/dep: Go dependency management tool"
-[Context]: https://golang.org/pkg/context/ "context - The Go Programming Language"
+[gocli]: https://github.com/goark/gocli "goark/gocli: Minimal Packages for Command-Line Interface"
+[Context]: https://pkg.go.dev/context "context - Go Packages"
+[Task]: https://taskfile.dev "Task - A task runner / simpler Make alternative"


### PR DESCRIPTION
## Summary

Step 1 of repository organization: align project docs and instructions.

### Changes

- **Add `.github/copilot-instructions.md`** with:
  - Project purpose
  - Design principles
  - Coding style guidance
  - Error handling policy
  - Testing/validation commands (`task test`)
  - Release process steps

- **Update `README.md`**:
  - Add Go Reference badge
  - Add Design goals section listing all sub-packages
  - Add Development section documenting `task test`
  - Remove outdated migration notice and `dep` link
  - Fix Go version requirement (1.16 → 1.20)
  - Update Context link to pkg.go.dev
  - Clean up trailing whitespace