### PR TITLE
refactor: fix comment style to idiomatic Go

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,7 +1,7 @@
 // Package cache : User cache file and directory
 //
 // These codes are licensed under CC0.
-// http://creativecommons.org/publicdomain/zero/1.0/
+// http:// creativecommons.org/publicdomain/zero/1.0/
 package cache
 
 import (
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-//Path returns path of user cache file
+// Path returns path of user cache file
 func Path(appName, fileName string) string {
 	if len(fileName) == 0 || includeSlash(fileName) {
 		return ""
@@ -22,7 +22,7 @@ func Path(appName, fileName string) string {
 	return filepath.Join(dir, fileName)
 }
 
-//Dir returns user cache directory
+// Dir returns user cache directory
 func Dir(appName string) string {
 	if includeSlash(appName) {
 		return ""

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,7 @@
 // Package config : Configuration file and directory
 //
 // These codes are licensed under CC0.
-// http://creativecommons.org/publicdomain/zero/1.0/
+// http:// creativecommons.org/publicdomain/zero/1.0/
 package config
 
 import (
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-//Path returns path of Configuration file
+// Path returns path of Configuration file
 func Path(appName, fileName string) string {
 	if len(fileName) == 0 || includeSlash(fileName) {
 		return ""
@@ -22,7 +22,7 @@ func Path(appName, fileName string) string {
 	return filepath.Join(dir, fileName)
 }
 
-//Dir returns Configuration directory
+// Dir returns Configuration directory
 func Dir(appName string) string {
 	if includeSlash(appName) {
 		return ""

--- a/exitcode/exitcode.go
+++ b/exitcode/exitcode.go
@@ -1,7 +1,7 @@
 // Package exitcode : OS exit code enumeration
 //
 // These codes are licensed under CC0.
-// http://creativecommons.org/publicdomain/zero/1.0/
+// http:// creativecommons.org/publicdomain/zero/1.0/
 package exitcode
 
 import "os"
@@ -10,9 +10,9 @@ import "os"
 type ExitCode int
 
 const (
-	//Normal is OS exit code "normal"
+	// Normal is OS exit code "normal"
 	Normal ExitCode = iota
-	//Abnormal is OS exit code "abnormal"
+	// Abnormal is OS exit code "abnormal"
 	Abnormal
 )
 

--- a/exitcode/exitcode_test.go
+++ b/exitcode/exitcode_test.go
@@ -3,7 +3,7 @@ package exitcode
 import "testing"
 
 func TestExitCode(t *testing.T) {
-	testCases := []struct { //Test case for ExitCode
+	testCases := []struct { // Test case for ExitCode
 		ec  ExitCode
 		str string
 	}{

--- a/file/glob.go
+++ b/file/glob.go
@@ -1,7 +1,7 @@
 // Package file : Operating files and directories
 //
 // These codes are licensed under CC0.
-// http://creativecommons.org/publicdomain/zero/1.0/
+// http:// creativecommons.org/publicdomain/zero/1.0/
 package file
 
 import (
@@ -11,10 +11,10 @@ import (
 	"strings"
 )
 
-//GlobFlag is type of operation flag in Glob() function.
+// GlobFlag is type of operation flag in Glob() function.
 type GlobFlag uint
 
-//Operation flag in Glob() function.
+// Operation flag in Glob() function.
 const (
 	GlobContainsFile GlobFlag = 1 << iota
 	GlobContainsDir
@@ -23,35 +23,35 @@ const (
 	GlobStdFlags = GlobContainsFile | GlobContainsDir
 )
 
-//ContainsFile returns status of GlobContainsFile.
+// ContainsFile returns status of GlobContainsFile.
 func (f GlobFlag) ContainsFile() bool {
 	return (f & GlobContainsFile) != 0
 }
 
-//ContainsDir returns status of GlobContainsDir.
+// ContainsDir returns status of GlobContainsDir.
 func (f GlobFlag) ContainsDir() bool {
 	return (f & GlobContainsDir) != 0
 }
 
-//SeparatorSlash returns status of GlobSeparatorSlash.
+// SeparatorSlash returns status of GlobSeparatorSlash.
 func (f GlobFlag) SeparatorSlash() bool {
 	return (f & GlobSeparatorSlash) != 0
 }
 
-//AbsolutePath returns status of GlobAbsolutePath.
+// AbsolutePath returns status of GlobAbsolutePath.
 func (f GlobFlag) AbsolutePath() bool {
 	return (f & GlobAbsolutePath) != 0
 }
 
-//GlobOption is setting for Glob() function.
+// GlobOption is setting for Glob() function.
 type GlobOption struct {
 	flags GlobFlag
 }
 
-//GlogOptFunc is self-referential function for functional options pattern.
+// GlogOptFunc is self-referential function for functional options pattern.
 type GlogOptFunc func(*GlobOption)
 
-//NewGlobOption returns GlobOption instance
+// NewGlobOption returns GlobOption instance
 func NewGlobOption(opts ...GlogOptFunc) *GlobOption {
 	o := &GlobOption{flags: GlobStdFlags}
 	for _, opt := range opts {
@@ -60,14 +60,14 @@ func NewGlobOption(opts ...GlogOptFunc) *GlobOption {
 	return o
 }
 
-//WithFlags returns function for setting GlobOption.
+// WithFlags returns function for setting GlobOption.
 func WithFlags(f GlobFlag) GlogOptFunc {
 	return func(o *GlobOption) {
 		o.flags = f
 	}
 }
 
-//Glob returns an array containing the matching directory/file names.
+// Glob returns an array containing the matching directory/file names.
 func Glob(path string, opt *GlobOption) []string {
 	if path == "" {
 		return []string{}
@@ -171,7 +171,7 @@ func walkDir(root string) []string {
 
 func normalizePath(path string, mode os.FileMode) string {
 	tail := ""
-	if (mode & os.ModeDir) != 0 { //directory
+	if (mode & os.ModeDir) != 0 { // directory
 		tail = string(filepath.Separator)
 	}
 	return filepath.Clean(path) + tail

--- a/rwi/rwi.go
+++ b/rwi/rwi.go
@@ -1,7 +1,7 @@
 // Package rwi : Reader/Writer Interface for command-line
 //
 // These codes are licensed under CC0.
-// http://creativecommons.org/publicdomain/zero/1.0/
+// http:// creativecommons.org/publicdomain/zero/1.0/
 package rwi
 
 import (
@@ -17,7 +17,7 @@ type RWI struct {
 	errorWriter io.Writer
 }
 
-//OptFunc is self-referential function for functional options pattern
+// OptFunc is self-referential function for functional options pattern
 type OptFunc func(*RWI)
 
 // New returns a new RWI instance
@@ -29,7 +29,7 @@ func New(opts ...OptFunc) *RWI {
 	return c
 }
 
-//WithReader returns function for setting Reader
+// WithReader returns function for setting Reader
 func WithReader(r io.Reader) OptFunc {
 	return func(c *RWI) {
 		if r != nil {
@@ -38,7 +38,7 @@ func WithReader(r io.Reader) OptFunc {
 	}
 }
 
-//WithWriter returns function for setting Writer
+// WithWriter returns function for setting Writer
 func WithWriter(w io.Writer) OptFunc {
 	return func(c *RWI) {
 		if w != nil {
@@ -47,7 +47,7 @@ func WithWriter(w io.Writer) OptFunc {
 	}
 }
 
-//WithErrorWriter returns function for setting Writer (error)
+// WithErrorWriter returns function for setting Writer (error)
 func WithErrorWriter(e io.Writer) OptFunc {
 	return func(c *RWI) {
 		if e != nil {
@@ -56,70 +56,70 @@ func WithErrorWriter(e io.Writer) OptFunc {
 	}
 }
 
-//Reader returns RWI.reader
+// Reader returns RWI.reader
 func (c *RWI) Reader() io.Reader {
 	return c.reader
 }
 
-//Writer returns RWI.writer
+// Writer returns RWI.writer
 func (c *RWI) Writer() io.Writer {
 	return c.writer
 }
 
-//ErrorWriter returns RWI.errorWriter
+// ErrorWriter returns RWI.errorWriter
 func (c *RWI) ErrorWriter() io.Writer {
 	return c.errorWriter
 }
 
-//Output output to RWI.writer
+// Output output to RWI.writer
 func (c *RWI) Output(val ...interface{}) error {
 	return doOutput(c.writer, val)
 }
 
-//Outputln output to  RWI.writer (add newline).
+// Outputln output to  RWI.writer (add newline).
 func (c *RWI) Outputln(val ...interface{}) error {
 	return doOutputln(c.writer, val)
 }
 
-//OutputBytes to  RWI.writer ([]byte data).
+// OutputBytes to  RWI.writer ([]byte data).
 func (c *RWI) OutputBytes(data []byte) error {
 	return c.WriteFrom(bytes.NewReader(data))
 }
 
-//WriteFrom  copy from io.Reader to RWI.writer
+// WriteFrom  copy from io.Reader to RWI.writer
 func (c *RWI) WriteFrom(r io.Reader) error {
 	_, err := io.Copy(c.writer, r)
 	return err
 }
 
-//OutputErr output to  RWI.errorWriter
+// OutputErr output to  RWI.errorWriter
 func (c *RWI) OutputErr(val ...interface{}) error {
 	return doOutput(c.errorWriter, val)
 }
 
-//OutputErrln output to  RWI.errorWriter (add newline).
+// OutputErrln output to  RWI.errorWriter (add newline).
 func (c *RWI) OutputErrln(val ...interface{}) error {
 	return doOutputln(c.errorWriter, val)
 }
 
-//OutputErrBytes copy to  RWI.errorWriter ([]byte data).
+// OutputErrBytes copy to  RWI.errorWriter ([]byte data).
 func (c *RWI) OutputErrBytes(data []byte) error {
 	return c.WriteErrFrom(bytes.NewReader(data))
 }
 
-//WriteErrFrom copy from io.Reader to RWI.errorWriter
+// WriteErrFrom copy from io.Reader to RWI.errorWriter
 func (c *RWI) WriteErrFrom(r io.Reader) error {
 	_, err := io.Copy(c.errorWriter, r)
 	return err
 }
 
-//Output to io.Writer (internal)
+// Output to io.Writer (internal)
 func doOutput(writer io.Writer, val []interface{}) error {
 	_, err := fmt.Fprint(writer, val...)
 	return err
 }
 
-//Output to io.Writer (add newline, internal)
+// Output to io.Writer (add newline, internal)
 func doOutputln(writer io.Writer, val []interface{}) error {
 	_, err := fmt.Fprintln(writer, val...)
 	return err

--- a/rwi/rwi_test.go
+++ b/rwi/rwi_test.go
@@ -14,7 +14,7 @@ var inputMsg string
 var lineEnding string
 
 func TestMain(m *testing.M) {
-	//initialization
+	// initialization
 	inputMsgs = []string{
 		"Take the Go-lang!",
 		"Go言語で行こう！",
@@ -26,10 +26,10 @@ func TestMain(m *testing.M) {
 		lineEnding = "\n"
 	}
 
-	//start test
+	// start test
 	code := m.Run()
 
-	//termination
+	// termination
 	os.Exit(code)
 }
 

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -1,7 +1,7 @@
 // Package signal : Handling SIGNAL with context package
 //
 // These codes are licensed under CC0.
-// http://creativecommons.org/publicdomain/zero/1.0/
+// http:// creativecommons.org/publicdomain/zero/1.0/
 package signal
 
 import (
@@ -10,7 +10,7 @@ import (
 	signl "os/signal"
 )
 
-//Context returns context.Context with Cancel
+// Context returns context.Context with Cancel
 func Context(parent context.Context, sig ...os.Signal) context.Context {
 	cctx, cancel := context.WithCancel(parent)
 	go func() {
@@ -23,7 +23,7 @@ func Context(parent context.Context, sig ...os.Signal) context.Context {
 		select {
 		case <-cctx.Done(): // cancel event from parent context
 			return
-		case <-sigCh: //catch SIGNAL
+		case <-sigCh: // catch SIGNAL
 			return
 		}
 	}()


### PR DESCRIPTION
## Summary

Step 3 of repository organization: fix comment style across all Go source files.

### Changes

- Add missing space after `//` in all `.go` files: `//Foo` → `// Foo`
- Applies to all sub-packages: `exitcode`, `rwi`, `signal`, `file`, `config`, `cache`
- Includes test files (`exitcode_test.go`, `rwi_test.go`)

All existing tests pass (`go test -shuffle on ./...`).