### PR TITLE
build: bump Go version from 1.20 to 1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GitHub release](https://img.shields.io/github/release/goark/gocli.svg)](https://github.com/goark/gocli/releases/latest)
 [![Go Reference](https://pkg.go.dev/badge/github.com/goark/gocli.svg)](https://pkg.go.dev/github.com/goark/gocli)
 
-This package requires Go 1.20 or later.
+This package requires Go 1.25 or later.
 
 ## Design goals
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,7 +26,7 @@ tasks:
       - '**/*.go'
 
   prepare:
-      - go mod tidy -v -go=1.20
+      - go mod tidy -v -go=1.25
 
   clean:
     desc: Initialize module and build cache, and remake go.sum file.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/goark/gocli
 
-go 1.20
+go 1.25
 
 toolchain go1.26.3


### PR DESCRIPTION
## Summary

Go 1.20 is no longer officially supported. Bump to Go 1.25 which is still within the supported release window.

### Changes

- `go.mod`: `go 1.20` → `go 1.25`
- `Taskfile.yml`: `prepare` task `-go=1.20` → `-go=1.25`
- `README.md`: update Go version requirement mention