### PR TITLE
deprecate: mark signal package as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Each package addresses a single concern:
 
 - `exitcode` — OS exit code constants and helpers
 - `rwi` — Reader/Writer interface wrapping stdin/stdout/stderr
-- `signal` — Signal handling via `context.Context`
+- `signal` — Signal handling via `context.Context` (deprecated: use [`os/signal.NotifyContext`](https://pkg.go.dev/os/signal#NotifyContext) instead)
 - `file` — File/directory globbing with wildcard support
 - `config` — XDG-aware configuration file path helpers
 - `cache` — XDG-aware cache file path helpers

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -2,6 +2,9 @@
 //
 // These codes are licensed under CC0.
 // http:// creativecommons.org/publicdomain/zero/1.0/
+//
+// Deprecated: This package is deprecated. Use [os/signal.NotifyContext] instead,
+// which provides equivalent functionality as part of the Go standard library since Go 1.16.
 package signal
 
 import (
@@ -11,6 +14,8 @@ import (
 )
 
 // Context returns context.Context with Cancel
+//
+// Deprecated: Use [os/signal.NotifyContext] instead.
 func Context(parent context.Context, sig ...os.Signal) context.Context {
 	cctx, cancel := context.WithCancel(parent)
 	go func() {


### PR DESCRIPTION
## Summary

Mark the `signal` sub-package as deprecated.

### Reason

The Go standard library has provided [`os/signal.NotifyContext`](https://pkg.go.dev/os/signal#NotifyContext) since Go 1.16, which offers equivalent (and more complete) functionality. There is no reason to maintain this wrapper.

### Changes

- `signal/signal.go`: add `Deprecated:` notice to package doc comment and `Context()` function
- `README.md`: note the deprecation with a link to `os/signal.NotifyContext`